### PR TITLE
Add the Juniper book to the list

### DIFF
--- a/src/applications.md
+++ b/src/applications.md
@@ -6,4 +6,5 @@ Applications of Rust:
 * [Roguelike Tutorial - In Rust](https://bfnightly.bracketproductions.com/) - [Roguelike](https://en.wikipedia.org/wiki/Roguelike) game development
 * [intermezzOS OS](http://intermezzos.github.io/book/second-edition/)
 * [Prusti user guide](https://viperproject.github.io/prusti-dev/user-guide/) - a Rust verifier
+* [Juniper](https://graphql-rust.github.io/juniper/current/) - GraphQL Server for Rust
 * [mdBook](https://rust-lang.github.io/mdBook/)


### PR DESCRIPTION
This PR adds the Juniper book ([released version](https://graphql-rust.github.io/juniper/current), [master](https://graphql-rust.github.io/juniper/master/))