### PR TITLE
Correct entry for "The (unofficial) Rust FFI Guide"

### DIFF
--- a/src/unofficial.md
+++ b/src/unofficial.md
@@ -31,7 +31,7 @@ Application domains:
 * [CXX — Safe Interop Between Rust and C++](https://cxx.rs)
 * [Triangle From Scratch](https://rust-tutorials.github.io/triangle-from-scratch/) - draw a triangle using Win32, but no external crates
 * [Writing Interpreters in Rust: a Guide](https://rust-hosted-langs.github.io/book/introduction.html)
-* [Using Unsafe for Fun and Profit](http://jakegoulding.com/rust-ffi-omnibus/) - FFI in depth
+* [The (unofficial) Rust FFI Guide](https://michael-f-bryan.github.io/rust-ffi-guide/) - FFI in depth
 
 Other:
 * [Secure Rust Guidelines](https://anssi-fr.github.io/rust-guide/)


### PR DESCRIPTION
- Use the correct URL
- List it under the book's title, rather than the first chapter's long title

Re: #22