### PR TITLE
Add Comprehensive Rust 🦀

### DIFF
--- a/src/unofficial.md
+++ b/src/unofficial.md
@@ -4,8 +4,8 @@ The following books are maintained outside [rust-lang.org](https://www.rust-lang
 
 Introductory:
 * [A Gentle Introduction To Rust](https://stevedonovan.github.io/rust-gentle-intro/readme.html)
-* [Comprehensive Rust 🦀](https://google.github.io/comprehensive-rust/) - a multi-day course developed by Google to teach Rust to Android engineers
 * [_A half-hour to learn Rust_](https://fasterthanli.me/articles/a-half-hour-to-learn-rust)
+* [Comprehensive Rust 🦀](https://google.github.io/comprehensive-rust/) - a multi-day course developed by Google to teach Rust to Android engineers
 * [`Dyner`](https://dyner.netlify.app/) - experimental trait (_dyn_) objects in Rust
 * [Easy Rust](https://dhghomon.github.io/easy_rust/) - aimed at non-English native speakers
 * [Effective Rust](https://www.lurklurk.org/effective-rust/) - Rust guidelines[^effectiverust]

--- a/src/unofficial.md
+++ b/src/unofficial.md
@@ -4,6 +4,7 @@ The following books are maintained outside [rust-lang.org](https://www.rust-lang
 
 Introductory:
 * [A Gentle Introduction To Rust](https://stevedonovan.github.io/rust-gentle-intro/readme.html)
+* [Comprehensive Rust 🦀](https://google.github.io/comprehensive-rust/) - a multi-day course developed by Google to teach Rust to Android engineers
 * [_A half-hour to learn Rust_](https://fasterthanli.me/articles/a-half-hour-to-learn-rust)
 * [`Dyner`](https://dyner.netlify.app/) - experimental trait (_dyn_) objects in Rust
 * [Easy Rust](https://dhghomon.github.io/easy_rust/) - aimed at non-English native speakers


### PR DESCRIPTION
I would suggest adding the Comprehensive Rust 🦀 course to the list of introductory guides.

I put it after the "A Gentle Introduction To Rust" since it's similar in that it tries to cover all of the language (but it's much longer).