### PR TITLE
misc updates and reorg

### DIFF
--- a/src/applications.md
+++ b/src/applications.md
@@ -2,6 +2,7 @@
 
 Applications of Rust:
 * [_An Introduction to Chip-8 Emulation using the Rust Programming Language_](https://github.com/aquova/chip8-book/releases) - PDF book
+* [A thoughtful introduction to the pest parser](https://pest.rs/book/) - a library for writing plain-text parsers
 * [Build a Lua Interpreter in Rust](https://wubingzheng.github.io/build-lua-in-rust/en/)
 * [Book of crosvm](https://google.github.io/crosvm/) - a hosted (a.k.a. type-2) virtual machine monitor
 * [Create Your Own Programming Language with Rust](https://createlang.rs/)
@@ -22,6 +23,10 @@ Applications of Rust:
   * [Writing NES Emulator in Rust](https://bugzmanov.github.io/nes_ebook/index.html) - NES is the Nintendo Entertainment System gaming platform
 * GPU development
   * [Rust GPU Dev Guide](https://embarkstudios.github.io/rust-gpu/book/)
+* GraphQL
+  * [Async-graphql Book](https://async-graphql.github.io/async-graphql/en/index.html) - GraphQL server-side library
+  * [Cynic - A GraphQL Client For Rust](https://cynic-rs.dev/)
+  * [Juniper - GraphQL Server for Rust](https://graphql-rust.github.io/)
 * GUI development
   * [Druid](https://linebender.org/druid/)
   * [GUI development with Relm4](https://relm4.org/book/stable/)

--- a/src/official.md
+++ b/src/official.md
@@ -28,12 +28,12 @@ Working groups:
 * [wg-async](https://rust-lang.github.io/wg-async/) - foundations of async I/O
 
 Other:
-* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/)
+* [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) - non-blocking coroutines
 * [Clippy Documentation](https://doc.rust-lang.org/nightly/clippy/development/infrastructure/book.html)
 * [Criterion.rs](https://bheisler.github.io/criterion.rs/book/getting_started.html) - statistics-driven micro-benchmarking
-* [mdBook](https://rust-lang.github.io/mdBook/)
+* [mdBook](https://rust-lang.github.io/mdBook/) - code lints for programmers
 * [Polonius](https://rust-lang.github.io/polonius/) - experimental borrow checker crate
-* [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+* [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - how to design and present APIs
 * [Rust RFCs](https://rust-lang.github.io/rfcs/)
 * [The Chalk Book](https://rust-lang.github.io/chalk/book/) - Rust's new trait system implementation
-* [The `bindgen` User Guide](https://rust-lang.github.io/rust-bindgen/)
+* [The `bindgen` User Guide](https://rust-lang.github.io/rust-bindgen/) - "RFC" (request for comments) for changes to Rust

--- a/src/official.md
+++ b/src/official.md
@@ -31,6 +31,7 @@ Other:
 * [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) - non-blocking coroutines
 * [Clippy Documentation](https://doc.rust-lang.org/nightly/clippy/development/infrastructure/book.html) - code lints for programmers
 * [Criterion.rs](https://bheisler.github.io/criterion.rs/book/getting_started.html) - statistics-driven micro-benchmarking
+* [Error Codes Index](https://doc.rust-lang.org/stable/error_codes/error-index.html) - list of all error codes emitted from the Rust compiler 
 * [mdBook](https://rust-lang.github.io/mdBook/) - documentation for rendering and serving markdown books
 * [Polonius](https://rust-lang.github.io/polonius/) - experimental borrow checker crate
 * [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - how to design and present APIs

--- a/src/official.md
+++ b/src/official.md
@@ -29,11 +29,11 @@ Working groups:
 
 Other:
 * [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) - non-blocking coroutines
-* [Clippy Documentation](https://doc.rust-lang.org/nightly/clippy/development/infrastructure/book.html)
+* [Clippy Documentation](https://doc.rust-lang.org/nightly/clippy/development/infrastructure/book.html) - code lints for programmers
 * [Criterion.rs](https://bheisler.github.io/criterion.rs/book/getting_started.html) - statistics-driven micro-benchmarking
-* [mdBook](https://rust-lang.github.io/mdBook/) - code lints for programmers
+* [mdBook](https://rust-lang.github.io/mdBook/) - documentation for rendering and serving markdown books
 * [Polonius](https://rust-lang.github.io/polonius/) - experimental borrow checker crate
 * [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - how to design and present APIs
-* [Rust RFCs](https://rust-lang.github.io/rfcs/)
+* [Rust RFCs](https://rust-lang.github.io/rfcs/) - "RFC" (request for comments) for changes to Rust
 * [The Chalk Book](https://rust-lang.github.io/chalk/book/) - Rust's new trait system implementation
-* [The `bindgen` User Guide](https://rust-lang.github.io/rust-bindgen/) - "RFC" (request for comments) for changes to Rust
+* [The `bindgen` User Guide](https://rust-lang.github.io/rust-bindgen/) - automatically generates Rust FFI bindings to C and C++ libraries

--- a/src/official.md
+++ b/src/official.md
@@ -32,9 +32,9 @@ Other:
 * [Clippy Documentation](https://doc.rust-lang.org/nightly/clippy/development/infrastructure/book.html) - code lints for programmers
 * [Criterion.rs](https://bheisler.github.io/criterion.rs/book/getting_started.html) - statistics-driven micro-benchmarking
 * [Error Codes Index](https://doc.rust-lang.org/stable/error_codes/error-index.html) - list of all error codes emitted from the Rust compiler 
-* [mdBook](https://rust-lang.github.io/mdBook/) - documentation for rendering and serving markdown books
+* [mdBook](https://rust-lang.github.io/mdBook/) - authoring, rendering and serving markdown books
 * [Polonius](https://rust-lang.github.io/polonius/) - experimental borrow checker crate
 * [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - how to design and present APIs
-* [Rust RFCs](https://rust-lang.github.io/rfcs/) - "RFC" (request for comments) for changes to Rust
+* [Rust RFCs](https://rust-lang.github.io/rfcs/) - list of Requests For Comments for changes to Rust
 * [The Chalk Book](https://rust-lang.github.io/chalk/book/) - Rust's new trait system implementation
 * [The `bindgen` User Guide](https://rust-lang.github.io/rust-bindgen/) - automatically generates Rust FFI bindings to C and C++ libraries

--- a/src/unofficial.md
+++ b/src/unofficial.md
@@ -36,7 +36,6 @@ Introductory:
 
 
 Application domains:
-* [A thoughtful introduction to the pest parser](https://pest.rs/book/)
 * Async
   * [Async programming in Rust with async-std](https://book.async.rs/introduction.html)
   * [Async Raft](https://async-raft.github.io/async-raft/) - the Raft distributed consensus protocol in async Rust
@@ -55,15 +54,10 @@ Application domains:
   * [The Embedonomicon](https://docs.rust-embedded.org/embedonomicon/) - build a `#![no_std]` application from scratch
   * [The Rust on ESP Book](https://esp-rs.github.io/book/) - comprehensive guide on using the Rust programming language with Espressif SoCs and modules.
   * [Workbook for Embedded Workshops](https://embedded-trainings.ferrous-systems.com/preparations.html) - an embedded Rust workshop
-* [Engineering Rust Web Applications](https://erwabook.com/)
 * Foreign Function Interface (FFI)
   * [_The Rust FFI Omnibus_](http://jakegoulding.com/rust-ffi-omnibus/)
   * [The (unofficial) Rust FFI Guide](https://michael-f-bryan.github.io/rust-ffi-guide/) - FFI in depth
   * [Using Unsafe for Fun and Profit](https://michael-f-bryan.github.io/rust-ffi-guide/)
-* GraphQL
-  * [Async-graphql Book](https://async-graphql.github.io/async-graphql/en/index.html) - GraphQL server-side library
-  * [Cynic - A GraphQL Client For Rust](https://cynic-rs.dev/)
-  * [Juniper - GraphQL Server for Rust](https://graphql-rust.github.io/)
 * [Real-Time Interrupt-driven Concurrency](https://rtic.rs/)
 * [Triangle From Scratch](https://rust-tutorials.github.io/triangle-from-scratch/) - draw a triangle using Win32, but no external crates
 * Web assembly


### PR DESCRIPTION
Added descriptors for the rest of the official references.

Moves GraphQL references from unofficial to official based on categorization.

Removed a link to non-present content.