### PR TITLE
Bump Ubuntu CI runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test_and_maybe_deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub is dropping support of 20.04 in April.